### PR TITLE
feat(SLI-91): add celery worker to docker compose

### DIFF
--- a/backend/Dev.Dockerfile
+++ b/backend/Dev.Dockerfile
@@ -13,4 +13,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY ./app /app
 
 # Run the FastAPI app
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/Dev.Dockerfile.celery
+++ b/backend/Dev.Dockerfile.celery
@@ -1,0 +1,24 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  unzip \
+  gcc \
+  libffi-dev \
+  musl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy & Install Python dependencies
+COPY requirements.txt requirements.txt
+COPY requirements-dev.txt requirements-dev.txt
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+# Copy application code
+COPY ./app /app
+
+# Run Celery worker with watchdog
+CMD ["watchmedo", "auto-restart", "-d", ".", "-R", "-p", "*.py", "--debug-force-polling", "--", "celery", "-A", "video_extractor.celery", "worker", "--loglevel=info", "-c", "16"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y unzip
 
 # Install Python dependencies
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY ./app /app

--- a/backend/Dockerfile.celery
+++ b/backend/Dockerfile.celery
@@ -1,5 +1,7 @@
+# Base image
 FROM python:3.9-slim
 
+# Set working directory
 WORKDIR /app
 
 # Install system dependencies
@@ -15,11 +17,8 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install watchdog for auto-reloading
-RUN pip install watchdog[watchmedo]
-
 # Copy application code
 COPY ./app /app
 
-# Run Celery worker with watchdog
-CMD ["watchmedo", "auto-restart", "-d", ".", "-R", "-p", "*.py", "--debug-force-polling", "--", "celery", "-A", "video_extractor.celery", "worker", "--loglevel=info", "-c", "16"]
+# Set the default command to run Celery worker
+CMD ["celery", "-A", "video_extractor.celery", "worker", "--loglevel=info", "-c", "16"]

--- a/backend/Dockerfile.celery
+++ b/backend/Dockerfile.celery
@@ -1,0 +1,25 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  unzip \
+  gcc \
+  libffi-dev \
+  musl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install watchdog for auto-reloading
+RUN pip install watchdog[watchmedo]
+
+# Copy application code
+COPY ./app /app
+
+# Run Celery worker with watchdog
+CMD ["watchmedo", "auto-restart", "-d", ".", "-R", "-p", "*.py", "--debug-force-polling", "--", "celery", "-A", "video_extractor.celery", "worker", "--loglevel=info", "-c", "16"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -50,6 +50,13 @@ As seen here: https://github.com/SlideSpeak/image-extractor-cli/blob/30c5ad96ffb
 
 ***
 
+### Celery
+
+Celery is running on a docker container.
+You can use celery by implementing the decorator on the function you wish to queue.
+Then you should use `.delay` to trigger the celery queue which will return the task id.
+After that you can query the celery worker for the result, if any.
+
 ### Coding
 
 Now we know what the python script should look like.
@@ -61,9 +68,7 @@ Fast API route:
 	- file: file.pptx
 
 ##### NOTE:
-	I am happy :D !!!
-	I learnt something new!
-	How to make a test with postman when a post requires a named file parameter.
+	How to make a test with postman when a post requires a named file parameter?
 	You should go to postman and change the request to a post.
 	Then on the Body section choose form-data.
 	Then hover on the `Key` section and choose "File" on the dropdown.

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,11 +2,61 @@
 
 - Having Docker installed on your system.
 
-## Running the docker container
+## Running the docker containers
 
-```bash
-docker compose up --build
-```
+The project includes a `Makefile` to simplify common Docker Compose tasks. You can use the following commands to manage your development and production environments:
+
+### Available Commands
+
+| Command       | Description                                                                                 |
+|---------------|---------------------------------------------------------------------------------------------|
+| `make start`  | Starts the development environment using `docker-compose.yml`.                             |
+| `make build`  | Builds the Docker images and starts the development environment.                           |
+| `make detach` | Builds the Docker images, starts the development environment in detached mode (background). |
+| `make down`   | Stops and removes all containers, networks, and volumes defined in `docker-compose.yml`.   |
+| `make prod`   | Starts the production environment using `docker-compose.prod.yml`.                         |
+| `make prod-down` | Stops and removes all containers, networks, and volumes defined in `docker-compose.prod.yml`. |
+
+---
+
+### How to Use
+
+1. **Start Development Environment**:
+   - Run the following command to start your development environment:
+     ```bash
+     make start
+     ```
+   - This command will spin up the containers as defined in `docker-compose.yml`.
+
+2. **Build and Start Containers**:
+   - If you’ve made changes to your Dockerfile or dependencies, rebuild the containers with:
+     ```bash
+     make build
+     ```
+
+3. **Run in Detached Mode**:
+   - To run the containers in the background, use:
+     ```bash
+     make detach
+     ```
+
+4. **Shut Down the Environment**:
+   - To stop and clean up all containers, networks, and volumes, run:
+     ```bash
+     make down
+     ```
+
+5. **Start Production Environment**:
+   - Use this command to start the production environment defined in `docker-compose.prod.yml`:
+     ```bash
+     make prod
+     ```
+
+6. **Shut Down Production Environment**:
+   - To stop and clean up the production containers, use:
+     ```bash
+     make prod-down
+     ```
 
 ***
 

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -28,12 +28,7 @@ services:
       dockerfile: Dockerfile.celery
     container_name: celery_worker_prod
     command: >
-      watchmedo auto-restart 
-      -d . 
-      -R 
-      -p '*.py' 
-      --debug-force-polling 
-      -- celery -A video_extractor.celery worker --loglevel=info -c 16
+      celery -A video_extractor.celery worker --loglevel=info -c 16
     volumes:
       - shared_tmp:/shared_tmp
     env_file: 

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -2,8 +2,8 @@ services:
   backend:
     build:
       context: .
-      dockerfile: Dev.Dockerfile
-    container_name: backend_dev
+      dockerfile: Dockerfile
+    container_name: backend_prod
     ports:
       - "8000:8000"
     depends_on:
@@ -18,15 +18,15 @@ services:
 
   redis:
     image: redis:6.2
-    container_name: redis_dev
+    container_name: redis_prod
     ports:
       - "6379:6379"
       
   celery_worker:
     build:
       context: .
-      dockerfile: Dev.Dockerfile.celery
-    container_name: celery_worker_dev
+      dockerfile: Dockerfile.celery
+    container_name: celery_worker_prod
     command: >
       watchmedo auto-restart 
       -d . 
@@ -35,7 +35,6 @@ services:
       --debug-force-polling 
       -- celery -A video_extractor.celery worker --loglevel=info -c 16
     volumes:
-      - ./app:/app # For development you do want to share this volume to get notified when the app changes
       - shared_tmp:/shared_tmp
     env_file: 
       - path: ".env"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       -- celery -A video_extractor.celery worker --loglevel=info -c 16
     volumes:
       - shared_tmp:/shared_tmp
+    env_file: 
+      - path: ".env"
+        required: true
     depends_on:
       - redis
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - redis
     volumes:
       - ./app:/app
+      - shared_tmp:/shared_tmp
     env_file: 
       - path: ".env"
         required: true
@@ -15,4 +16,23 @@ services:
   redis:
     image: redis:6.2
     ports:
-      - "6342:6379"
+      - "6379:6379"
+      
+  celery_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.celery
+    command: >
+      watchmedo auto-restart 
+      -d . 
+      -R 
+      -p '*.py' 
+      --debug-force-polling 
+      -- celery -A video_extractor.celery worker --loglevel=info -c 16
+    volumes:
+      - shared_tmp:/shared_tmp
+    depends_on:
+      - redis
+
+volumes:
+  shared_tmp:

--- a/backend/makefile
+++ b/backend/makefile
@@ -11,7 +11,7 @@ down:
 	docker compose -f docker-compose.yml down
 
 prod:
-	docker compose -f docker-compose.prod.yml up
+	docker compose -f docker-compose.prod.yml up --build
 
 prod-down:
 	docker compose -f docker-compose.prod.yml down

--- a/backend/makefile
+++ b/backend/makefile
@@ -1,0 +1,17 @@
+start:
+	docker compose -f docker-compose.yml up
+
+build:
+	docker compose -f docker-compose.yml up --build
+
+detach:
+	docker compose -f docker-compose.yml up --build -d
+
+down:
+	docker compose -f docker-compose.yml down
+
+prod:
+	docker compose -f docker-compose.prod.yml up
+
+prod-down:
+	docker compose -f docker-compose.prod.yml down

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development-specific requirements
+watchdog[watchmedo]==6.0.0


### PR DESCRIPTION
- [X] Add a celery worker service to `docker-compose.yml`.
- [X] Ensure the worker is configured to use the Redis service as its broker and backend.
- [X] Create a lightweight celery worker image.
- [X] Shared volume (`/shared_tmp`) for the backend container and celery container. (Allow celery to access files created on the backend from `/shared_tmp`)
- [X] Document the addition in the README or a separate setup guide.
