### PR TITLE
chore: Implement uuid4() for unique file names

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from video_extractor import extract_videos_task, celery
 from config import ALLOWED_ORIGINS, LOCAL_DOCUMENTS_DIR
 from celery.result import AsyncResult
 import os
+import uuid
 
 app = FastAPI()
 
@@ -23,7 +24,7 @@ async def extract_videos(file: UploadFile):
         raise HTTPException(status_code=400, detail="Invalid file type. Please upload a PowerPoint file.")
     
     # Save file temporarily
-    temp_path = f"/{LOCAL_DOCUMENTS_DIR}/{file.filename}"
+    temp_path = f"/{LOCAL_DOCUMENTS_DIR}/{uuid.uuid4()}_{file.filename}"
     with open(temp_path, "wb") as f:
         content = await file.read()
         f.write(content)


### PR DESCRIPTION
- [X] Replace direct use of file.filename with a UUID-based file name.
- [X] Test the solution. See test details bellow.
- [X] Files are uniquely named using UUIDs, preventing conflicts.

    Format: `<uuid.uuid4()>_filename`
    Ex: `4f3439aa-b11d-4475-9368-5f5c08d62837_CodingChallengePresentation.pptx`

<details>
<summary>test</summary>

## See the body, the uuid is included in the url

<img width="1010" alt="Screenshot 2024-12-03 at 18 11 54" src="https://github.com/user-attachments/assets/8348a997-486a-47c4-ad8c-6e95d71080b4">

</details>